### PR TITLE
support single gpu multiple models loading

### DIFF
--- a/service_streamer/service_streamer.py
+++ b/service_streamer/service_streamer.py
@@ -149,6 +149,10 @@ class _BaseStreamWorker(object):
         self._max_latency = max_latency
         self._destroy_event = kwargs.get("destroy_event", None)
 
+        warm_up_batch = kwargs.get("warm_up", None)
+        if warm_up_batch:
+            self._predict(warm_up_batch)
+
     def run_forever(self, *args, **kwargs):
         self._pid = os.getpid()  # overwrite the pid
         logger.info("[gpu worker %d] %s start working" % (self._pid, self))


### PR DESCRIPTION
A tensorflow model reserves as much gpu space as possible when it loads. If multiple models are loaded at the same time they cause resource conflict and no models can start, therefore they must be loaded one by one. "warm_up" option in the Streamer object can force models to load one by one.