### PR TITLE
Configurable WORKER_TIMEOUT

### DIFF
--- a/service_streamer/service_streamer.py
+++ b/service_streamer/service_streamer.py
@@ -15,7 +15,7 @@ from redis import Redis
 
 from .managed_model import ManagedModel
 
-TIMEOUT = 1
+TIMEOUT = 100
 TIME_SLEEP = 0.001
 WORKER_TIMEOUT = 20
 logger = logging.getLogger(__name__)

--- a/service_streamer/service_streamer.py
+++ b/service_streamer/service_streamer.py
@@ -15,9 +15,9 @@ from redis import Redis
 
 from .managed_model import ManagedModel
 
-TIMEOUT = 100
+TIMEOUT = 1
 TIME_SLEEP = 0.001
-WORKER_TIMEOUT = 20
+WORKER_TIMEOUT = 2000
 logger = logging.getLogger(__name__)
 logger.setLevel("INFO")
 


### PR DESCRIPTION
Hi guys,

I made a tiny improvement on service_streamer to make WORKER_TIMEOUT configurable. In some applications such as machine translation, prediction time can exceed WORKER_TIMEOUT. This solves the problem by making WORKER_TIMEOUT configurable for users when Streamer is created.

Sorry for dirty commits - please squash them when merging.